### PR TITLE
Avoid timer overflow

### DIFF
--- a/hpgl.js
+++ b/hpgl.js
@@ -2738,7 +2738,7 @@ Plotter.prototype.queue = function(instruction, callback = null, options = {}) {
   }
 
   // If the queue is not set for execution, set it.
-  if (this._queueTimeOutId === 0) {
+  if (this._queueTimeOutId === 0 && this._retryTimeoutId === 0) {
     this._queueTimeOutId = setTimeout(this._processQueue.bind(this), this.QUEUE_DELAY);
   }
 


### PR DESCRIPTION
This change adds a check that prevents multiple copies of the processQueue timeout from being created (which eventually either crashes node or makes the plotter act possessed as these multiple copies interact in weird ways).

**Explanation**
The flow today is:

1. A timer is set up to call _processQueue
2. When _processQueue is called, that timer is cleared and the handle to that timer is set to 0
3. An asynchronous call is made to the plotter to check the remaining space available in the buffer. At the same time, a retry timer is set up in case the plotter never responds
4. Either the plotter responds or the retry timer triggers. In either case, the retry timer is cleared and set to 0, and a timer is set up to call _processQueue - bringing us back to step one.

Today, if the queue() method is called after step 2 has finished but _before_ step 4 executes, then a new timer is set up to call _processQueue in queue() (see line 2829) and then a _second_ timer is set up when step 4 eventually executes.

On long/complex plots, this is likely to happen often - leading to hundreds of parallel threads of execution that can interact in very weird ways.

This change prevents that by checking whether the retry timer is active before setting up a new timer to call _processQueue. If the retry timer is active, we can infer that we are somewhere in-between steps 2 and 4 and so the queue does not need to be set for execution again.

**Testing**
I tested this with multiple complex (1 hour+ plots). Before this change, most of those plots ended in random scribbles. After this change, those plots complete without issue.